### PR TITLE
Fix camelCase for mediaDiaria variable

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1559,9 +1559,9 @@ document.addEventListener('DOMContentLoaded', function () {
         const diasDecorridos = Math.ceil((hoje - dataInicioCiclo) / (1000 * 60 * 60 * 24)) + 1;
         
         const totalAtual = getTotalGastosMes(mesAtual);
-        const mediadiaria = totalAtual / diasDecorridos;
-        
-        return mediadiaria * diasTotaisCiclo;
+        const mediaDiaria = totalAtual / diasDecorridos;
+
+        return mediaDiaria * diasTotaisCiclo;
     }
     
     // Função para obter últimos gastos importantes (acima da média)


### PR DESCRIPTION
## Summary
- rename `mediadiaria` variable to `mediaDiaria` for camelCase consistency

## Testing
- `grep -R "mediaDiaria" -n`


------
https://chatgpt.com/codex/tasks/task_e_68891513a62083248a8018354ea45aaa