### PR TITLE
Fix CSS rule termination

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4091,5 +4091,3 @@ body {
         0 4px 12px rgba(0, 0, 0, 0.1);
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
-
-.tab-btn.active


### PR DESCRIPTION
## Summary
- fix stray `.tab-btn.active` line at the end of `style.css`

## Testing
- `grep -o '{' assets/css/style.css | wc -l`
- `grep -o '}' assets/css/style.css | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6889151eb7fc8324935d72eddce514fe