### PR TITLE
Add Jest and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Este projeto está sob a licença MIT. Veja o arquivo `LICENSE` para mais detalh
 
 Se você encontrar algum problema ou tiver sugestões, por favor abra uma [issue](https://github.com/[seu-usuario]/controlada/issues).
 
+## 🧪 Testes
+
+Para executar os testes unitários utilize o npm:
+
+```bash
+npm install
+npm test
+```
+
 ---
 
 ⭐ Se este projeto te ajudou, não esqueça de dar uma estrela!

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1861,5 +1861,12 @@ document.addEventListener('DOMContentLoaded', function () {
     if (typeof atualizarDashboard === 'function') {
         atualizarDashboard();
     }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            getCycleKeyForDate,
+            getTotalGastosMes
+        };
+    }
     
 }); // Fecha DOMContentLoaded listener

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "controlada",
+  "version": "1.0.0",
+  "description": "Um sistema moderno de controle financeiro pessoal desenvolvido com HTML, CSS e JavaScript vanilla.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,40 @@
+const mainModule = require('../assets/js/main.js');
+
+describe('getCycleKeyForDate', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('returns same month when day >= start day', () => {
+    localStorage.setItem('config_inicio_mes', '5');
+    const { year, month } = mainModule.getCycleKeyForDate('2023-03-06');
+    expect(year).toBe(2023);
+    expect(month).toBe(3);
+  });
+
+  test('returns previous month when day < start day', () => {
+    localStorage.setItem('config_inicio_mes', '10');
+    const { year, month } = mainModule.getCycleKeyForDate(new Date('2023-03-05'));
+    expect(year).toBe(2023);
+    expect(month).toBe(2);
+  });
+});
+
+describe('getTotalGastosMes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('sums gastos for given month', () => {
+    localStorage.setItem('gastos_usuario', JSON.stringify([
+      { valor: '10', data: '2023-05-05' },
+      { valor: '15', data: '2023-05-20' },
+      { valor: '5',  data: '2023-06-01' }
+    ]));
+
+    const total = mainModule.getTotalGastosMes('2023-05');
+    expect(total).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary
- set up npm with Jest as devDependency
- export helper functions for testing
- add unit tests for financial cycle helpers
- explain running tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891524d78483248d39128425a79c29