### PR TITLE
Corrige exibição do modal de edição de renda

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,6 +27,144 @@ body {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+/* Modal editar renda */
+.modal-editar-renda {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(3px);
+    z-index: 2000;
+    overflow-y: auto;
+}
+
+.modal-editar-renda-content {
+    background: #ffffff;
+    color: var(--black);
+    border-radius: 24px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.18);
+    width: 100%;
+    max-width: 420px;
+    padding: 2.5rem 2rem;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+body[data-theme="dark"] .modal-editar-renda-content {
+    background: #2b2b2b;
+    color: #f1f1f1;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+.modal-editar-renda-content h3 {
+    margin: 0;
+    font-size: 1.8rem;
+    color: var(--dark-moss-green);
+}
+
+body[data-theme="dark"] .modal-editar-renda-content h3 {
+    color: var(--yellow-green);
+}
+
+.modal-editar-renda-content form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+#input-modal-renda {
+    width: 100%;
+    padding: 0.9rem 1.2rem;
+    border-radius: 12px;
+    border: 1px solid rgba(77, 102, 25, 0.25);
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--dark-moss-green);
+    background: rgba(255, 255, 255, 0.9);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+body[data-theme="dark"] #input-modal-renda {
+    background: rgba(28, 28, 28, 0.9);
+    color: #f1f1f1;
+    border-color: rgba(208, 231, 140, 0.4);
+}
+
+#input-modal-renda:focus {
+    outline: none;
+    border-color: var(--dark-moss-green);
+    box-shadow: 0 0 0 3px rgba(154, 205, 50, 0.25);
+}
+
+.modal-editar-renda-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.modal-editar-renda-salvar,
+.modal-editar-renda-cancelar {
+    border: none;
+    border-radius: 999px;
+    padding: 0.9rem 1.8rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.3s ease, color 0.3s ease;
+}
+
+.modal-editar-renda-salvar {
+    background: linear-gradient(135deg, var(--dark-moss-green), var(--yellow-green));
+    color: #ffffff;
+    box-shadow: 0 12px 24px rgba(77, 102, 25, 0.25);
+}
+
+.modal-editar-renda-salvar:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 30px rgba(77, 102, 25, 0.3);
+}
+
+.modal-editar-renda-cancelar {
+    background: rgba(154, 205, 50, 0.12);
+    color: var(--dark-moss-green);
+    border: 1px solid rgba(77, 102, 25, 0.25);
+}
+
+.modal-editar-renda-cancelar:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 20px rgba(154, 205, 50, 0.25);
+    background: rgba(154, 205, 50, 0.2);
+}
+
+.modal-editar-renda-close {
+    position: absolute;
+    top: 1rem;
+    right: 1.25rem;
+    font-size: 1.8rem;
+    color: rgba(77, 102, 25, 0.6);
+    cursor: pointer;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.modal-editar-renda-close:hover {
+    color: var(--dark-moss-green);
+    transform: scale(1.1);
+}
+
+body[data-theme="dark"] .modal-editar-renda-close {
+    color: rgba(240, 240, 240, 0.7);
+}
+
+body[data-theme="dark"] .modal-editar-renda-close:hover {
+    color: var(--yellow-green);
+}
+
 /* Garante que padding e border estão inclusos na largura de todos os elementos */
 *, *::before, *::after {
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- adiciona estilos para exibir o modal de renda como sobreposição centralizada
- estiliza conteúdo, botões e suporte ao tema escuro do modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafb6997a883249d16c9d2064489ca