### PR TITLE
Corrige inicialização dos filtros para reativar abas

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,11 +34,12 @@ body {
     display: none;
     align-items: center;
     justify-content: center;
-    padding: 2rem;
+    padding: 2rem 1.5rem;
     background: rgba(0, 0, 0, 0.45);
     backdrop-filter: blur(3px);
     z-index: 2000;
     overflow-y: auto;
+    box-sizing: border-box;
 }
 
 .modal-editar-renda-content {
@@ -48,11 +49,14 @@ body {
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.18);
     width: 100%;
     max-width: 520px;
+    max-height: min(90vh, 760px);
     padding: 2.5rem 2rem;
     position: relative;
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 body[data-theme="dark"] .modal-editar-renda-content {
@@ -1632,6 +1636,11 @@ body[data-theme="dark"] .beneficio-empty {
 
 /* Dispositivos móveis em paisagem */
 @media (max-width: 768px) {
+    .modal-editar-renda {
+        align-items: flex-start;
+        padding: 1.5rem 1rem;
+    }
+
     .main-header {
         padding: 0.3rem 0;
     }
@@ -1754,9 +1763,11 @@ body[data-theme="dark"] .beneficio-empty {
     }
     
     .modal-editar-renda-content {
-        min-width: 300px;
-        margin: 1rem;
+        width: 100%;
+        min-width: auto;
+        margin: 1rem auto;
         padding: 2rem 1.5rem;
+        max-height: calc(100vh - 2rem);
     }
     
     .modal-editar-renda-content h3 {
@@ -1771,6 +1782,16 @@ body[data-theme="dark"] .beneficio-empty {
 
 /* Dispositivos móveis pequenos */
 @media (max-width: 480px) {
+    .modal-editar-renda {
+        padding: 1.25rem 0.75rem;
+    }
+
+    .modal-editar-renda-content {
+        padding: 1.8rem 1.3rem;
+        border-radius: 20px;
+        max-height: calc(100vh - 1.5rem);
+    }
+
     .page-layout {
         padding-top: 160px;
         padding-left: 0.5rem;

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -98,6 +98,11 @@
     const filterCategoriaHistorico = document.getElementById('filter-categoria-historico');
     const filterMetodoHistorico = document.getElementById('filter-metodo-historico');
 
+    // Controle de filtros do histórico (precisa existir antes dos handlers que os utilizam)
+    let currentView = 'table';
+    let gastosOriginais = [];
+    let gastosFiltrados = [];
+
     function resolverCategoriaId(categoriaValor, categoriaIdExistente){
         if(categoriaIdExistente) return categoriaIdExistente;
         const categoriaEncontrada = dataService.getTodasCategorias().find(cat => cat.valor === categoriaValor);
@@ -760,11 +765,13 @@
     const textoCategoriaEmUso = document.getElementById('texto-categoria-em-uso');
 
     function abrirModalConfirmarExclusao(mesAno, idx) {
+        if (!modalConfirmar) return;
         mesAnoParaExcluir = mesAno;
         idxParaExcluir = idx;
         modalConfirmar.style.display = 'flex';
     }
     function fecharModalConfirmarExclusao() {
+        if (!modalConfirmar) return;
         modalConfirmar.style.display = 'none';
         mesAnoParaExcluir = null;
         idxParaExcluir = null;
@@ -772,40 +779,57 @@
 
     // Funções para o modal de categoria em uso
     function abrirModalCategoriaEmUso(nomeCategoria, quantidadeGastos) {
+        if (!modalCategoriaEmUso || !textoCategoriaEmUso) return;
         textoCategoriaEmUso.innerHTML = `
-            Não foi possível excluir a categoria <strong>"${nomeCategoria}"</strong> 
+            Não foi possível excluir a categoria <strong>"${nomeCategoria}"</strong>
             pois existem <strong>${quantidadeGastos} gasto(s)</strong> usando-a.
             <br><br>
-            Para excluir esta categoria, primeiro remova ou altere a categoria 
+            Para excluir esta categoria, primeiro remova ou altere a categoria
             dos gastos que a utilizam.
         `;
         modalCategoriaEmUso.style.display = 'flex';
     }
-    
+
     function fecharModalCategoriaEmUso() {
-        modalCategoriaEmUso.style.display = 'none';
-    }
-    btnCancelarExclusao.addEventListener('click', fecharModalConfirmarExclusao);
-    modalConfirmarClose.addEventListener('click', fecharModalConfirmarExclusao);
-    modalConfirmar.addEventListener('click', function(e) {
-        if (e.target === modalConfirmar) fecharModalConfirmarExclusao();
-    });
-    btnConfirmarExclusao.addEventListener('click', function() {
-        if (mesAnoParaExcluir && idxParaExcluir !== null) {
-            excluirGastoDoMes(mesAnoParaExcluir, idxParaExcluir, true);
-            fecharModalConfirmarExclusao();
+        if (modalCategoriaEmUso) {
+            modalCategoriaEmUso.style.display = 'none';
         }
-    });
+    }
+    if (btnCancelarExclusao) {
+        btnCancelarExclusao.addEventListener('click', fecharModalConfirmarExclusao);
+    }
+    if (modalConfirmarClose) {
+        modalConfirmarClose.addEventListener('click', fecharModalConfirmarExclusao);
+    }
+    if (modalConfirmar) {
+        modalConfirmar.addEventListener('click', function(e) {
+            if (e.target === modalConfirmar) fecharModalConfirmarExclusao();
+        });
+    }
+    if (btnConfirmarExclusao) {
+        btnConfirmarExclusao.addEventListener('click', function() {
+            if (mesAnoParaExcluir && idxParaExcluir !== null) {
+                excluirGastoDoMes(mesAnoParaExcluir, idxParaExcluir, true);
+                fecharModalConfirmarExclusao();
+            }
+        });
+    }
     // --- Fim modal confirmação ---
 
     // Event listeners para o modal de categoria em uso
-    btnEntendiCategoria.addEventListener('click', fecharModalCategoriaEmUso);
-    modalCategoriaEmUsoClose.addEventListener('click', fecharModalCategoriaEmUso);
-    modalCategoriaEmUso.addEventListener('click', function(e) {
-        if (e.target === modalCategoriaEmUso) {
-            fecharModalCategoriaEmUso();
-        }
-    });
+    if (btnEntendiCategoria) {
+        btnEntendiCategoria.addEventListener('click', fecharModalCategoriaEmUso);
+    }
+    if (modalCategoriaEmUsoClose) {
+        modalCategoriaEmUsoClose.addEventListener('click', fecharModalCategoriaEmUso);
+    }
+    if (modalCategoriaEmUso) {
+        modalCategoriaEmUso.addEventListener('click', function(e) {
+            if (e.target === modalCategoriaEmUso) {
+                fecharModalCategoriaEmUso();
+            }
+        });
+    }
 
     // Atualiza tabela de gastos para o mês selecionado
     function atualizarHistoricoGastos(mesAno) {
@@ -1021,7 +1045,10 @@
 
     if (menuToggleBtn) {
         menuToggleBtn.addEventListener('click', () => {
-            document.querySelector('.sidebar-col').classList.toggle('show-sidebar');
+            const sidebarCol = document.querySelector('.sidebar-col');
+            if (sidebarCol) {
+                sidebarCol.classList.toggle('show-sidebar');
+            }
         });
     }
 
@@ -1040,13 +1067,20 @@
     const savedTheme = localStorage.getItem('tema_preferido') || 'default';
     applyTheme(savedTheme);
 
-    const navLinks = document.querySelectorAll('.nav-list a');
+    const navLinks = document.querySelectorAll('.nav-list a[data-section]');
     const logoutLink = document.getElementById('logout-link');
     const sections = {
-        'Gastos': document.getElementById('tela-gastos'),
-        'Investimentos': document.getElementById('tela-investimentos'),
-        'Configurações': document.getElementById('tela-configuracoes')
+        'tela-gastos': document.getElementById('tela-gastos'),
+        'tela-investimentos': document.getElementById('tela-investimentos'),
+        'tela-configuracoes': document.getElementById('tela-configuracoes')
     };
+
+    navLinks.forEach(link => {
+        const targetId = link.dataset.section;
+        if (targetId && !sections[targetId]) {
+            sections[targetId] = document.getElementById(targetId);
+        }
+    });
 
     // Mostrar/esconder campo de método personalizado
     if (selectMetodo) {
@@ -1071,24 +1105,30 @@
     }
 
     // Exibe a primeira tela por padrão
-    showSection('Gastos');
+    showSection('tela-gastos');
 
     // Ao trocar de seção, mostrar/ocultar cadastro de categoria
-    function showSection(sectionName) {
-        Object.values(sections).forEach(sec => sec.style.display = 'none');
-        if (sections[sectionName]) {
-            sections[sectionName].style.display = 'block';
+    function showSection(sectionId) {
+        Object.values(sections).forEach(sec => {
+            if (sec) {
+                sec.style.display = 'none';
+            }
+        });
+        if (sections[sectionId]) {
+            sections[sectionId].style.display = 'block';
         }
         if (divCadastroCategoria) {
-            divCadastroCategoria.style.display = (sectionName === 'Gastos') ? 'block' : 'none';
+            divCadastroCategoria.style.display = (sectionId === 'tela-gastos') ? 'block' : 'none';
         }
     }
 
     navLinks.forEach(link => {
         link.addEventListener('click', function (e) {
             e.preventDefault();
-            const sectionName = link.textContent.trim();
-            showSection(sectionName);
+            const sectionId = this.dataset.section;
+            if (sectionId) {
+                showSection(sectionId);
+            }
         });
     });
 
@@ -1096,7 +1136,10 @@
     if (bottomNav) {
         bottomNav.querySelectorAll('button').forEach(btn => {
             btn.addEventListener('click', () => {
-                document.querySelector(`.tab-btn[data-tab="${btn.dataset.tab}"]`).click();
+                const targetButton = document.querySelector(`.tab-btn[data-tab="${btn.dataset.tab}"]`);
+                if (targetButton) {
+                    targetButton.click();
+                }
             });
         });
     }
@@ -1262,10 +1305,6 @@
     const cardsView = document.getElementById('cards-view');
     
     // Variáveis de controle
-    let currentView = 'table';
-    let gastosOriginais = [];
-    let gastosFiltrados = [];
-    
     // Função para aplicar todos os filtros
     function aplicarFiltros() {
         const mesAno = getMesAnoSelecionado();

--- a/index.html
+++ b/index.html
@@ -31,9 +31,9 @@
             <button id="theme-toggle" class="theme-toggle" aria-label="Tema">🌓</button>
             <span id="recorrentes-alert" class="recorrentes-alert" style="display:none;">🔔</span>
             <ul class="nav-list">
-                <li><a href="#">Gastos</a></li>
-                <li><a href="#">Investimentos</a></li>
-                <li><a href="#">Configurações</a></li>
+                <li><a href="#" data-section="tela-gastos">Gastos</a></li>
+                <li><a href="#" data-section="tela-investimentos">Investimentos</a></li>
+                <li><a href="#" data-section="tela-configuracoes">Configurações</a></li>
                 <li><a href="#" id="logout-link">Sair</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
## Summary
- limita a altura do modal de edição de renda, adicionando rolagem interna e ajustes responsivos para evitar cortes na tela
- torna a navegação superior mais resiliente usando data attributes e validações antes de manipular o DOM, prevenindo falhas nas abas e ações
- protege listeners de modais de confirmação/aviso contra elementos ausentes para evitar interrupções do script
- inicializa variáveis dos filtros do histórico antes dos listeners, prevenindo o ReferenceError que impedia as abas e botões de funcionarem

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb07f2adb883248cfaa5c83b4f344e