### PR TITLE
Corrige CSS quebrado por bloco não fechado

### DIFF
--- a/assets/css/missing-styles.css
+++ b/assets/css/missing-styles.css
@@ -495,6 +495,7 @@
 .gasto-card .status-chip,
 .gasto-card .installment-chip {
     margin-top: 0.35rem;
+}
 /* ===== AUDITORIA DE RENDA E CONCILIAÇÃO ===== */
 .config-extra-grid {
     margin-top: 2.5rem;


### PR DESCRIPTION
## Resumo
- adiciona a chave de fechamento faltante no bloco dos chips de status
- restaura a aplicação dos estilos posteriores na folha `missing-styles.css`

## Testes
- não foram executados (alteração apenas de CSS)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692384ce619c8324809f0cceb1628e8a)